### PR TITLE
change the way to use scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ if ($user->isCreated())
 ```php
 Route::get('login', function () {
     return Socialite::with('kuainiu')
-        ->scopes(['profiles.read']) // Additional permission: profiles.read
+        ->scopes('profiles.read profiles.write') // Additional permission: profiles.read profiles.write(the string need space separator)
         ->redirect();
 });
 

--- a/src/KuainiuConnectProvider.php
+++ b/src/KuainiuConnectProvider.php
@@ -12,7 +12,7 @@ use Laravel\Socialite\Two\User;
 class KuainiuConnectProvider extends AbstractProvider implements ProviderInterface
 {
 
-    protected $scopes = ['user_basic'];
+    protected $scopes = [];
     protected $domain = 'https://kuainiu.io';
 
     protected function getAuthUrl($state)


### PR DESCRIPTION
客户端用socialite包处理scopes，但服务端用league\oauth2-server处理scope，两者的处理方式不一致
因为在服务端做validScope之前 客户端传递过来的scope会被转为类似"user_basic,scope_one,scope_two"这样的字符串，字符串在被explode为数组时是以空格作为分隔符的，所以会导致无法正确解析scopes